### PR TITLE
#2 Change default branch name

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,7 @@ parser.addArgument(
 parser.addArgument(['-b', '--branch'], 
 {
     help: '--b <branch name>',
-    defaultValue: 'master',
+    defaultValue: 'main',
     required: false
 });
 


### PR DESCRIPTION
GitHub has changed it's default production branch name from `master` to `main`.

Making a PR that updates it.